### PR TITLE
Adds basic iterator for CFG object

### DIFF
--- a/staticfg/model.py
+++ b/staticfg/model.py
@@ -231,9 +231,9 @@ class CFG(object):
 
         while to_visit:
             block = to_visit.pop(0)
-            visited.add(block.id)
+            visited.add(block)
             for exit_ in block.exits:
-                if exit_.target.id in visited:
+                if exit_.target in visited or exit_.target in to_visit:
                     continue
                 to_visit.append(exit_.target)
             yield block

--- a/staticfg/model.py
+++ b/staticfg/model.py
@@ -220,3 +220,23 @@ class CFG(object):
         """
         graph = self._build_visual(format, calls)
         graph.render(filepath, view=show)
+
+    def __iter__(self):
+        """
+        Generator that yields all the blocks in the current graph, then
+        recursively yields from any sub graphs
+        """
+        visited = set()
+        to_visit = [self.entryblock]
+
+        while to_visit:
+            block = to_visit.pop(0)
+            visited.add(block.id)
+            for exit_ in block.exits:
+                if exit_.target.id in visited:
+                    continue
+                to_visit.append(exit_.target)
+            yield block
+
+        for subcfg in self.functioncfgs.values():
+            yield from subcfg

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 import unittest
 import ast
 from staticfg.model import *
+from staticfg.builder import CFGBuilder
 
 
 class TestBlock(unittest.TestCase):
@@ -111,6 +112,24 @@ class TestCFG(unittest.TestCase):
         cfg = CFG('cfg', False)
         self.assertEqual(str(cfg), 'CFG for cfg')
 
+    def test_iter(self):
+        src = """\
+def fib():
+    a, b = 0, 1
+    while True:
+        yield a
+        a, b = b, a + b
+"""
+        cfg = CFGBuilder().build_from_src("fib", src)
+        expected_block_sources = [
+            "def fib():...\n",
+            "a, b = 0, 1\n",
+            "while True:\n",
+            "yield a\n",
+            "a, b = b, a + b\n"
+        ]
+        for actual_block, expected_src in zip(cfg, expected_block_sources):
+            self.assertEqual(actual_block.get_source(), expected_src)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a basic `__iter__` method using the generator pattern. The blocks are yielded in the same order that they are processed by the `build_visual` logic, but I am open to alternative orderings or other improvements/changes to this logic.

P.s. thanks for the library! Very useful and was not around back when I started static analysis work in Python, seems much cleaner and reusable than my old code.