### PR TITLE
Add support for break statements

### DIFF
--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -32,6 +32,9 @@ def invert(node):
         op = type(node.ops[0])
         inverse_node = ast.Compare(left=node.left, ops=[inverse[op]()],
                                    comparators=node.comparators)
+    elif isinstance(node, ast.BinOp) and type(node.op) in inverse:
+        op = type(node.op)
+        inverse_node = ast.BinOp(node.left, inverse[op](), node.right)
     elif type(node) == ast.NameConstant and node.value in [True, False]:
         inverse_node = ast.NameConstant(value=not node.value)
     else:
@@ -342,8 +345,8 @@ class CFGBuilder(ast.NodeVisitor):
         self.after_loop_block = afterwhile_block
         inverted_test = invert(node.test)
         # Skip edge for while True:
-        if not isinstance(inverted_test, ast.NameConstant) and \
-                inverted_test.value == False:
+        if not (isinstance(inverted_test, ast.NameConstant) and \
+                inverted_test.value == False):
             self.add_exit(self.current_block, afterwhile_block, )
 
         # Populate the while block.

--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -347,7 +347,7 @@ class CFGBuilder(ast.NodeVisitor):
         # Skip edge for while True:
         if not (isinstance(inverted_test, ast.NameConstant) and \
                 inverted_test.value == False):
-            self.add_exit(self.current_block, afterwhile_block, )
+            self.add_exit(self.current_block, afterwhile_block, inverted_test)
 
         # Populate the while block.
         self.current_block = while_block

--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -340,7 +340,11 @@ class CFGBuilder(ast.NodeVisitor):
         # New block for the case where the test in the while is False.
         afterwhile_block = self.new_block()
         self.after_loop_block = afterwhile_block
-        self.add_exit(self.current_block, afterwhile_block, invert(node.test))
+        inverted_test = invert(node.test)
+        # Skip edge for while True:
+        if not isinstance(inverted_test, ast.NameConstant) and \
+                inverted_test.value == False:
+            self.add_exit(self.current_block, afterwhile_block, )
 
         # Populate the while block.
         self.current_block = while_block

--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -342,6 +342,7 @@ class CFGBuilder(ast.NodeVisitor):
 
         # New block for the case where the test in the while is False.
         afterwhile_block = self.new_block()
+        prev_after_loop_block = getattr(self, "after_loop_block", None)
         self.after_loop_block = afterwhile_block
         inverted_test = invert(node.test)
         # Skip edge for while True:
@@ -357,7 +358,7 @@ class CFGBuilder(ast.NodeVisitor):
 
         # Continue building the CFG in the after-while block.
         self.current_block = afterwhile_block
-        self.after_loop_block = None
+        self.after_loop_block = prev_after_loop_block
 
     def visit_For(self, node):
         loop_guard = self.new_loopguard()

--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -69,6 +69,10 @@ class CFGBuilder(ast.NodeVisitor):
     a program's AST and iteratively build the corresponding CFG.
     """
 
+    def __init__(self):
+        super().__init__()
+        self.after_loop_block = None
+
     # ---------- CFG building methods ---------- #
     def build(self, name, tree, asynchr=False, entry_id=0):
         """
@@ -342,7 +346,7 @@ class CFGBuilder(ast.NodeVisitor):
 
         # New block for the case where the test in the while is False.
         afterwhile_block = self.new_block()
-        prev_after_loop_block = getattr(self, "after_loop_block", None)
+        prev_after_loop_block = self.after_loop_block
         self.after_loop_block = afterwhile_block
         inverted_test = invert(node.test)
         # Skip edge for while True:
@@ -383,8 +387,7 @@ class CFGBuilder(ast.NodeVisitor):
         self.current_block = afterfor_block
 
     def visit_Break(self, node):
-        # TODO
-        assert getattr(self, "after_loop_block", False)
+        assert self.after_loop_block is not None, "Found break not inside loop"
         self.add_exit(self.current_block, self.after_loop_block)
 
     def visit_Continue(self, node):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -139,6 +139,10 @@ def foo():
         i += 1
         if i == 3:
             break
+    for j in range(3):
+        i += j
+        if j == 2:
+            break
     return i
 """
         cfg = CFGBuilder().build_from_src("foo", src)
@@ -149,6 +153,35 @@ def foo():
             "i += 1\n"
             "if i == 3:\n",
             "",
+            "for j in range(3):\n",
+            "i += j\n"
+            "if j == 2:\n",
+            "return i\n",
+            "",
+        ]
+        for actual_block, expected_src in zip(cfg, expected_block_sources):
+            self.assertEqual(actual_block.get_source(), expected_src)
+
+    def test_break_in_main_body(self):
+        src = """\
+def foo():
+    i = 0
+    while True:
+        i += 1
+        break
+    for j in range(3):
+        i += j
+        break
+    return i
+"""
+        cfg = CFGBuilder().build_from_src("foo", src)
+        expected_block_sources = [
+            "def foo():...\n",
+            "i = 0\n",
+            "while True:\n",
+            "i += 1\n",
+            "for j in range(3):\n",
+            "i += j\n",
             "return i\n"
         ]
         for actual_block, expected_src in zip(cfg, expected_block_sources):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -131,5 +131,28 @@ def fib():
         for actual_block, expected_src in zip(cfg, expected_block_sources):
             self.assertEqual(actual_block.get_source(), expected_src)
 
+    def test_break(self):
+        src = """\
+def foo():
+    i = 0
+    while True:
+        i += 1
+        if i == 3:
+            break
+    return i
+"""
+        cfg = CFGBuilder().build_from_src("foo", src)
+        expected_block_sources = [
+            "def foo():...\n",
+            "i = 0\n",
+            "while True:\n",
+            "i += 1\n"
+            "if i == 3:\n",
+            "",
+            "return i\n"
+        ]
+        for actual_block, expected_src in zip(cfg, expected_block_sources):
+            self.assertEqual(actual_block.get_source(), expected_src)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This supports break statements by tracking the exit of the current loop block (after_loop_block_stack will hav a new after loop block pushed on after a loop is encountered, then popped off after the loop visiting is finished).  If a break is encountered inside a loop, it will retrieve the current after loop block and set the exit to be after the loop.   If there is a break in the main body of a loop, don't set the exit after the loop is visited, since the internal break statement already did that.