### PR TITLE
Continue statements

### DIFF
--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -389,6 +389,8 @@ class CFGBuilder(ast.NodeVisitor):
 
         # Continue building the CFG in the after-for block.
         self.current_block = afterfor_block
+        # Popping the current after loop stack,taking care of errors in case of nested for loops
+        self.after_loop_block_stack.pop()
 
     def visit_Break(self, node):
         assert len(self.after_loop_block_stack), "Found break not inside loop"

--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -72,6 +72,7 @@ class CFGBuilder(ast.NodeVisitor):
     def __init__(self):
         super().__init__()
         self.after_loop_block_stack = []
+        self.curr_loop_guard_stack = []
 
     # ---------- CFG building methods ---------- #
     def build(self, name, tree, asynchr=False, entry_id=0):
@@ -339,7 +340,7 @@ class CFGBuilder(ast.NodeVisitor):
         loop_guard = self.new_loopguard()
         self.current_block = loop_guard
         self.add_statement(self.current_block, node)
-
+        self.curr_loop_guard_stack.append(loop_guard)
         # New block for the case where the test in the while is True.
         while_block = self.new_block()
         self.add_exit(self.current_block, while_block, node.test)
@@ -364,12 +365,13 @@ class CFGBuilder(ast.NodeVisitor):
         # Continue building the CFG in the after-while block.
         self.current_block = afterwhile_block
         self.after_loop_block_stack.pop()
+        self.curr_loop_guard_stack.pop()
 
     def visit_For(self, node):
         loop_guard = self.new_loopguard()
         self.current_block = loop_guard
         self.add_statement(self.current_block, node)
-
+        self.curr_loop_guard_stack.append(loop_guard)
         # New block for the body of the for-loop.
         for_block = self.new_block()
         self.add_exit(self.current_block, for_block, node.iter)
@@ -391,15 +393,15 @@ class CFGBuilder(ast.NodeVisitor):
         self.current_block = afterfor_block
         # Popping the current after loop stack,taking care of errors in case of nested for loops
         self.after_loop_block_stack.pop()
+        self.curr_loop_guard_stack.pop()
 
     def visit_Break(self, node):
         assert len(self.after_loop_block_stack), "Found break not inside loop"
         self.add_exit(self.current_block, self.after_loop_block_stack[-1])
 
     def visit_Continue(self, node):
-        # TODO
-        pass
-
+        assert len(self.curr_loop_guard_stack), "Found continue outside loop"
+        self.add_exit(self.current_block,self.curr_loop_guard_stack[-1])
     def visit_Import(self, node):
         self.add_statement(self.current_block, node)
 

--- a/staticfg/builder.py
+++ b/staticfg/builder.py
@@ -241,11 +241,13 @@ class CFGBuilder(ast.NodeVisitor):
                     pred.source.exits.remove(pred)
 
             block.predecessors = []
-            for exit in block.exits:
+            # as the exits may be modified during the recursive call, it is unsafe to iterate on block.exits
+            # Created a copy of block.exits before calling clean cfg , and iterate over it instead.
+            for exit in block.exits[:]:
                 self.clean_cfg(exit.target, visited)
             block.exits = []
         else:
-            for exit in block.exits:
+            for exit in block.exits[:]:
                 self.clean_cfg(exit.target, visited)
 
     # ---------- AST Node visitor methods ---------- #


### PR DESCRIPTION
1.Adds support for continue statements 
2.Break statements were producing wrong output on nested for loops , debugged that
3.clean_cfg , was editing the block.exits ,while iterating over it (in the recursive calls), which sometimes led some empty blocks to be left .Created a copy of block.exits , which was then used to recursively call.
Sample test which shows the wrong output in the current master 
for 2)
```:python
def check():
    for i in range(n):
        for j in range(n):
            if i==j:
                break
            print(1)
        if i<10:
            break
        print(2)
```
for 3)
```:python
def f(x,t):
    l=0
    r=len(x)-1
    while(l<=r):
        mid=(l+r)//2 
        if x[mid]==t:
            break
        if x[mid]>t:
            r=mid-1
        else:l=mid+1
    return r
```
Also this is an amazing library.Thanks for putting this out there. :)